### PR TITLE
Add Oxygen to Inherits

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Karasa Jaga
 Comment=Tema ikon untuk Sundara OS
-Inherits=gnome,hicolor
+Inherits=oxygen,gnome,hicolor
 Example=directory-x-normal
 
 DisplayDepth=32


### PR DESCRIPTION
If using this icon theme in Plasma 5, this includes icons (for example, for Akregator in Kontact) that aren't overridden by Karasa Jaga.